### PR TITLE
Migrate to JRuby group ID and get things passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
+          cache: maven
 
       - name: Install dependencies
-        run: ./mvnw install -Dmaven.test.skip -Dinvoker.skip
+        run: ./mvnw install -B -Dmaven.test.skip -Dinvoker.skip
 
       - name: Run tests
-        run: ./mvnw verify -Pintegration-test
+        run: ./mvnw verify -B -Pintegration-test

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ there is maven repository with torquebox.org which delivers gem (only ruby and j
 
     <repositories>
       <repository>
-        <id>rubygems-release</id>
+        <id>mavengems</id>
         <url>http://rubygems-proxy.torquebox.org/releases</url>
       </repository>
     </repositories>
@@ -34,7 +34,7 @@ just add the gem-maven-plugin in your pom and execute the 'initialize'. that wil
     <build>
 	  <plugins>
         <plugin>
-          <groupId>de.saumya.mojo</groupId>
+          <groupId>org.jruby.maven</groupId>
           <artifactId>gem-maven-plugin</artifactId>
           <version>${jruby.plugins.version}</version>
           <executions>
@@ -56,7 +56,7 @@ example: execute bin/compass from the compass gem
 add the following to you pom
     
     <plugin>
-	  <groupId>de.saumya.mojo</groupId>
+	  <groupId>org.jruby.maven</groupId>
 	  <artifactId>gem-maven-plugin</artifactId>
       <version>@project.parent.version@</version>
       <executions>
@@ -75,7 +75,7 @@ this will execute **compass** from the compass gem during the *compile* phase. y
 
 
     <plugin>
-	  <groupId>de.saumya.mojo</groupId>
+	  <groupId>org.jruby.maven</groupId>
 	  <artifactId>gem-maven-plugin</artifactId>
         <version>@project.parent.version@</version>
         <executions>

--- a/gem-extension/pom.xml
+++ b/gem-extension/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>gem-extension</artifactId>

--- a/gem-extension/src/main/resources/META-INF/plexus/components.xml
+++ b/gem-extension/src/main/resources/META-INF/plexus/components.xml
@@ -9,7 +9,7 @@
       <configuration>
         <phases>
 	  <initialize>
-	    de.saumya.mojo:gem-maven-plugin:initialize
+	    org.jruby.maven:gem-maven-plugin:initialize
 	  </initialize>
 	  <process-resources>
 	    org.apache.maven.plugins:maven-resources-plugin:resources
@@ -18,13 +18,13 @@
 	    org.apache.maven.plugins:maven-compiler-plugin:compile
 	  </compile>
 	  <package>
-	    de.saumya.mojo:gem-maven-plugin:package
+	    org.jruby.maven:gem-maven-plugin:package
 	  </package>
 	  <install>
 	    org.apache.maven.plugins:maven-install-plugin:install
 	  </install>
 	  <deploy>
-	    de.saumya.mojo:gem-maven-plugin:push
+	    org.jruby.maven:gem-maven-plugin:push
 	  </deploy>
         </phases>
       </configuration>

--- a/gem-maven-plugin/pom.xml
+++ b/gem-maven-plugin/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>gem-maven-plugin</artifactId>

--- a/gem-maven-plugin/src/it/exec-args-with-spaces/pom.xml
+++ b/gem-maven-plugin/src/it/exec-args-with-spaces/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<configuration>

--- a/gem-maven-plugin/src/it/exec-embed/pom.xml
+++ b/gem-maven-plugin/src/it/exec-embed/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
       </plugin>

--- a/gem-maven-plugin/src/it/exec-file/pom.xml
+++ b/gem-maven-plugin/src/it/exec-file/pom.xml
@@ -1,13 +1,26 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-release</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -27,9 +40,16 @@
   </properties>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/gem-maven-plugin/src/it/execute-compass-with-gems-from-plugin/pom.xml
+++ b/gem-maven-plugin/src/it/execute-compass-with-gems-from-plugin/pom.xml
@@ -6,19 +6,43 @@
   <version>0.0.0</version>
   <pluginRepositories>
     <pluginRepository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
+    </pluginRepository>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <repositories>
+    <repository>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
+    </repository>
+  </repositories>
   <properties>
     <root.dir>${basedir}</root.dir>
     <gem.home>${root.dir}/target/rubygems</gem.home>
     <gem.path>${root.dir}/target/rubygems</gem.path>
   </properties>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
         <version>@project.parent.version@</version>
         <executions>

--- a/gem-maven-plugin/src/it/gem-sets/pom.xml
+++ b/gem-maven-plugin/src/it/gem-sets/pom.xml
@@ -3,18 +3,38 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
 	<artifactId>maven-clean-plugin</artifactId>
@@ -26,7 +46,7 @@
 	</executions>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<executions>

--- a/gem-maven-plugin/src/it/gemfile-to-pom-forced/invoker.properties
+++ b/gem-maven-plugin/src/it/gemfile-to-pom-forced/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals = de.saumya.mojo:gem-maven-plugin:${project.version}:pom
+invoker.goals = org.jruby.maven:gem-maven-plugin:${project.version}:pom
 invoker.mavenOpts = -client
 

--- a/gem-maven-plugin/src/it/gemfile-to-pom-forced/pom.xml
+++ b/gem-maven-plugin/src/it/gemfile-to-pom-forced/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/gem-maven-plugin/src/it/gemfile-to-pom/invoker.properties
+++ b/gem-maven-plugin/src/it/gemfile-to-pom/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals = de.saumya.mojo:gem-maven-plugin:${project.version}:pom
+invoker.goals = org.jruby.maven:gem-maven-plugin:${project.version}:pom
 invoker.mavenOpts = -client
 

--- a/gem-maven-plugin/src/it/gemfile-to-pom/pom.xml
+++ b/gem-maven-plugin/src/it/gemfile-to-pom/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/gem-maven-plugin/src/it/gemify-complex/pom.xml
+++ b/gem-maven-plugin/src/it/gemify-complex/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/gem-maven-plugin/src/it/gemify-pom/pom.xml
+++ b/gem-maven-plugin/src/it/gemify-pom/pom.xml
@@ -18,7 +18,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/gem-maven-plugin/src/it/gemify-simple/goals.txt
+++ b/gem-maven-plugin/src/it/gemify-simple/goals.txt
@@ -1,1 +1,1 @@
-de.saumya.mojo:gem-maven-plugin:gemify
+org.jruby.maven:gem-maven-plugin:gemify

--- a/gem-maven-plugin/src/it/gemify-simple/pom.xml
+++ b/gem-maven-plugin/src/it/gemify-simple/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/gem-maven-plugin/src/it/gems-with-compile-test-and-provided-scope/pom.xml
+++ b/gem-maven-plugin/src/it/gems-with-compile-test-and-provided-scope/pom.xml
@@ -4,10 +4,23 @@
   <groupId>com.example</groupId>
   <artifactId>gems-test</artifactId>
   <version>0.0.0</version>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-release</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -43,9 +56,16 @@
   </properties>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/gem-maven-plugin/src/it/gemspec-to-pom-forced/invoker.properties
+++ b/gem-maven-plugin/src/it/gemspec-to-pom-forced/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals = de.saumya.mojo:gem-maven-plugin:${project.version}:pom
+invoker.goals = org.jruby.maven:gem-maven-plugin:${project.version}:pom
 invoker.mavenOpts = -client
 

--- a/gem-maven-plugin/src/it/gemspec-to-pom-forced/pom.xml
+++ b/gem-maven-plugin/src/it/gemspec-to-pom-forced/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/gem-maven-plugin/src/it/gemspec-to-pom/invoker.properties
+++ b/gem-maven-plugin/src/it/gemspec-to-pom/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals = de.saumya.mojo:gem-maven-plugin:${project.version}:pom
+invoker.goals = org.jruby.maven:gem-maven-plugin:${project.version}:pom
 invoker.mavenOpts = -client
 

--- a/gem-maven-plugin/src/it/gemspec-to-pom/pom.xml
+++ b/gem-maven-plugin/src/it/gemspec-to-pom/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/gem-maven-plugin/src/it/include-rubygems-in-resources/pom.xml
+++ b/gem-maven-plugin/src/it/include-rubygems-in-resources/pom.xml
@@ -9,10 +9,22 @@
     <version>testing</version>
     <packaging>jar</packaging>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>sonatype</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
     <repositories>
         <repository>
-            <id>rubygems-release</id>
-            <url>http://rubygems-proxy.torquebox.org/releases</url>
+            <id>mavengems</id>
+            <url>mavengem:https://rubygems.org</url>
         </repository>
     </repositories>
     <dependencies>
@@ -42,9 +54,16 @@
   </properties>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>org.jruby.maven</groupId>
+                <artifactId>mavengem-wagon</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
-                <groupId>de.saumya.mojo</groupId>
+                <groupId>org.jruby.maven</groupId>
                 <artifactId>gem-maven-plugin</artifactId>
                 <version>@project.version@</version>
                 <configuration>

--- a/gem-maven-plugin/src/it/include-rubygems-in-test-resources-failure/pom.xml
+++ b/gem-maven-plugin/src/it/include-rubygems-in-test-resources-failure/pom.xml
@@ -5,10 +5,22 @@
   <groupId>com.example</groupId>
   <artifactId>rubygems-in-test-resources-failure</artifactId>
   <version>testing</version>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
   <repositories>
     <repository>
-      <id>rubygems-release</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
   <dependencies>
@@ -32,7 +44,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<executions>

--- a/gem-maven-plugin/src/it/include-rubygems-in-test-resources/pom.xml
+++ b/gem-maven-plugin/src/it/include-rubygems-in-test-resources/pom.xml
@@ -5,10 +5,22 @@
   <groupId>com.example</groupId>
   <artifactId>rubygems-in-test-resources</artifactId>
   <version>testing</version>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
   <repositories>
     <repository>
-      <id>rubygems-release</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
   <dependencies>
@@ -36,6 +48,13 @@
     <gem.path>${root.dir}/target/rubygems</gem.path>
   </properties>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
 	<artifactId>maven-compiler-plugin</artifactId>
@@ -46,7 +65,7 @@
 	</configuration>
       </plugin>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<executions>

--- a/gem-maven-plugin/src/it/initialize/pom.xml
+++ b/gem-maven-plugin/src/it/initialize/pom.xml
@@ -4,10 +4,22 @@
   <groupId>rubygems</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
   <repositories>
     <repository>
-      <id>rubygems-release</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
   <dependencies>
@@ -42,9 +54,16 @@
     <gem.path>${root.dir}/target/rubygems</gem.path>
   </properties>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
         <extensions>true</extensions>

--- a/gem-maven-plugin/src/it/install-gem-pom/pom.xml
+++ b/gem-maven-plugin/src/it/install-gem-pom/pom.xml
@@ -8,7 +8,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<extensions>true</extensions>

--- a/gem-maven-plugin/src/it/install-java-gem-pom/pom.xml
+++ b/gem-maven-plugin/src/it/install-java-gem-pom/pom.xml
@@ -8,7 +8,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<extensions>true</extensions>

--- a/gem-maven-plugin/src/it/install-pom-with-gemspec/pom.xml
+++ b/gem-maven-plugin/src/it/install-pom-with-gemspec/pom.xml
@@ -9,7 +9,7 @@
     <finalName>first</finalName>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <extensions>true</extensions>

--- a/gem-maven-plugin/src/it/jars-lock/pom.xml
+++ b/gem-maven-plugin/src/it/jars-lock/pom.xml
@@ -4,10 +4,22 @@
   <groupId>rubygems</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
   <repositories>
     <repository>
-      <id>rubygems-release</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
   <dependencies>
@@ -34,9 +46,16 @@
     <gem.path>${root.dir}/target/rubygems</gem.path>
   </properties>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/gem-maven-plugin/src/it/package-gem-artifact-from-gemspec-no-pom/invoker.properties
+++ b/gem-maven-plugin/src/it/package-gem-artifact-from-gemspec-no-pom/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals = de.saumya.mojo:gem-maven-plugin:${project.version}:package
+invoker.goals = org.jruby.maven:gem-maven-plugin:${project.version}:package
 invoker.mavenOpts = -client
 

--- a/gem-maven-plugin/src/it/package-gem-artifact-from-gemspec-pom/pom.xml
+++ b/gem-maven-plugin/src/it/package-gem-artifact-from-gemspec-pom/pom.xml
@@ -7,7 +7,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<configuration>

--- a/gem-maven-plugin/src/it/script-inside-pom-failure/pom.xml
+++ b/gem-maven-plugin/src/it/script-inside-pom-failure/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <configuration>

--- a/gem-maven-plugin/src/it/script-inside-pom-somewhere/pom.xml
+++ b/gem-maven-plugin/src/it/script-inside-pom-somewhere/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <configuration>

--- a/gem-maven-plugin/src/it/script-inside-pom-to-outputfile-somewhere/pom.xml
+++ b/gem-maven-plugin/src/it/script-inside-pom-to-outputfile-somewhere/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/gem-maven-plugin/src/it/script-inside-pom-to-outputfile/pom.xml
+++ b/gem-maven-plugin/src/it/script-inside-pom-to-outputfile/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/gem-maven-plugin/src/it/script-inside-pom/pom.xml
+++ b/gem-maven-plugin/src/it/script-inside-pom/pom.xml
@@ -3,14 +3,21 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>dummy</artifactId>
   <version>testing</version>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <configuration>

--- a/gem-maven-plugin/src/it/small-project/application/pom.xml
+++ b/gem-maven-plugin/src/it/small-project/application/pom.xml
@@ -6,11 +6,23 @@
   <version>0.0.0</version>
   <packaging>gem</packaging>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <repositories>
     <repository>
-      <id>rubygems-release</id>
-      <url>yhttp://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>ymavengem:https://rubygems.org</url>
     </repository>
   </repositories>  
 
@@ -35,7 +47,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
         <extensions>true</extensions>

--- a/gem-maven-plugin/src/it/small-project/ruby-world/pom.xml
+++ b/gem-maven-plugin/src/it/small-project/ruby-world/pom.xml
@@ -8,7 +8,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
         <extensions>true</extensions>

--- a/gem-maven-plugin/src/it/support-native-extensions/pending-pom.xml
+++ b/gem-maven-plugin/src/it/support-native-extensions/pending-pom.xml
@@ -25,7 +25,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/gem-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/gem-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -9,7 +9,7 @@
       <configuration>
         <phases>
    <initialize>
-     de.saumya.mojo:gem-maven-plugin:initialize
+     org.jruby.maven:gem-maven-plugin:initialize
    </initialize>
           <process-resources>
             org.apache.maven.plugins:maven-resources-plugin:resources
@@ -18,13 +18,13 @@
             org.apache.maven.plugins:maven-compiler-plugin:compile
           </compile>
           <package>
-     de.saumya.mojo:gem-maven-plugin:package
+     org.jruby.maven:gem-maven-plugin:package
    </package>
    <install>
             org.apache.maven.plugins:maven-install-plugin:install
    </install>
    <deploy>
-     de.saumya.mojo:gem-maven-plugin:push
+     org.jruby.maven:gem-maven-plugin:push
           </deploy>
         </phases>
       </configuration>
@@ -54,7 +54,7 @@
       <configuration>
         <phases>
    <initialize>
-     de.saumya.mojo:gem-maven-plugin:initialize
+     org.jruby.maven:gem-maven-plugin:initialize
    </initialize>
           <process-resources>
             org.apache.maven.plugins:maven-resources-plugin:resources
@@ -64,13 +64,13 @@
           </compile>
           <package>
      org.apache.maven.plugins:maven-jar-plugin:jar,
-     de.saumya.mojo:gem-maven-plugin:package
+     org.jruby.maven:gem-maven-plugin:package
    </package>
    <install>
             org.apache.maven.plugins:maven-install-plugin:install
    </install>
    <deploy>
-     de.saumya.mojo:gem-maven-plugin:push
+     org.jruby.maven:gem-maven-plugin:push
           </deploy>
         </phases>
       </configuration>

--- a/gem-parent-mojo/pom.xml
+++ b/gem-parent-mojo/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>gem-parent-mojo</artifactId>

--- a/gem-proxy/pom.xml
+++ b/gem-proxy/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>jruby-maven-plugins</artifactId>
-    <groupId>de.saumya.mojo</groupId>
+    <groupId>org.jruby.maven</groupId>
     <version>2.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>gem-proxy</artifactId>
@@ -12,7 +12,7 @@
   <url>http://github.com/mkristian/jruby-maven-plugins</url>
   <dependencies>
     <dependency>
-      <groupId>de.saumya.mojo</groupId>
+      <groupId>org.jruby.maven</groupId>
       <artifactId>ruby-tools</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/gem-proxy/src/it/directory-browsing/pom.xml
+++ b/gem-proxy/src/it/directory-browsing/pom.xml
@@ -7,7 +7,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-proxy/src/it/load-bundler-gem/pom.xml
+++ b/gem-proxy/src/it/load-bundler-gem/pom.xml
@@ -21,7 +21,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-proxy/src/it/load-bundler-prerelease-gem/pom.xml
+++ b/gem-proxy/src/it/load-bundler-prerelease-gem/pom.xml
@@ -21,7 +21,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-proxy/src/it/load-compass-gem/pom.xml
+++ b/gem-proxy/src/it/load-compass-gem/pom.xml
@@ -21,7 +21,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-proxy/src/it/load-copyright-header-gem/pom.xml
+++ b/gem-proxy/src/it/load-copyright-header-gem/pom.xml
@@ -21,7 +21,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-proxy/src/it/load-heroku-gem/pom.xml
+++ b/gem-proxy/src/it/load-heroku-gem/pom.xml
@@ -21,12 +21,12 @@
   <build>
     <plugins>
       <plugin>
-      	<groupId>de.saumya.mojo</groupId>
-      	<artifactId>gem-maven-plugin</artifactId>
-      	<version>@project.parent.version@</version>
-      	<configuration>
-      	  <includeOpenSSL>false</includeOpenSSL>
-      	</configuration>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>@project.parent.version@</version>
+        <configuration>
+          <includeOpenSSL>false</includeOpenSSL>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/gem-proxy/src/it/load-json-java-gem/pom.xml
+++ b/gem-proxy/src/it/load-json-java-gem/pom.xml
@@ -21,7 +21,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-proxy/src/it/load-signet-gem/pom.xml
+++ b/gem-proxy/src/it/load-signet-gem/pom.xml
@@ -27,7 +27,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-proxy/src/it/load-therubyrhino-gem/pom.xml
+++ b/gem-proxy/src/it/load-therubyrhino-gem/pom.xml
@@ -21,7 +21,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-proxy/src/it/load_leafy_with_jars/pom.xml
+++ b/gem-proxy/src/it/load_leafy_with_jars/pom.xml
@@ -21,7 +21,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-proxy/src/it/load_leafy_without_jars/pom.xml
+++ b/gem-proxy/src/it/load_leafy_without_jars/pom.xml
@@ -21,7 +21,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/gem-with-jar-extension/pom.xml
+++ b/gem-with-jar-extension/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>gem-with-jar-extension</artifactId>

--- a/gem-with-jar-extension/src/main/resources/META-INF/plexus/components.xml
+++ b/gem-with-jar-extension/src/main/resources/META-INF/plexus/components.xml
@@ -9,7 +9,7 @@
       <configuration>
         <phases>
 	  <initialize>
-	    de.saumya.mojo:gem-maven-plugin:initialize
+	    org.jruby.maven:gem-maven-plugin:initialize
 	  </initialize>
 	  <process-resources>
 	    org.apache.maven.plugins:maven-resources-plugin:resources
@@ -30,13 +30,13 @@
             org.apache.maven.plugins:maven-surefire-plugin:test
           </test>
 	  <package>
-	    de.saumya.mojo:gem-maven-plugin:package
+	    org.jruby.maven:gem-maven-plugin:package
 	  </package>
 	  <install>
 	    org.apache.maven.plugins:maven-install-plugin:install
 	  </install>
 	  <deploy>
-	    de.saumya.mojo:gem-maven-plugin:push
+	    org.jruby.maven:gem-maven-plugin:push
 	  </deploy>
         </phases>
       </configuration>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
+    <groupId>org.jruby.maven</groupId>
     <version>2.0.1-SNAPSHOT</version>
     <relativePath>../parent-mojo/pom.xml</relativePath>
   </parent>

--- a/integration-tests/src/it/big_gemfile2pom/invoker.properties
+++ b/integration-tests/src/it/big_gemfile2pom/invoker.properties
@@ -1,6 +1,6 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:pom de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:pom org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 invoker.goals.4 = verify
 invoker.mavenOpts = -client
 #invoker.offline = true

--- a/integration-tests/src/it/gemfile2pom/invoker.properties
+++ b/integration-tests/src/it/gemfile2pom/invoker.properties
@@ -1,6 +1,6 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:pom de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:pom org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 invoker.goals.4 = verify
 invoker.mavenOpts = -client
 #invoker.offline = true

--- a/integration-tests/src/it/new_latest_rails_mysql/invoker.properties
+++ b/integration-tests/src/it/new_latest_rails_mysql/invoker.properties
@@ -1,6 +1,6 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:rails de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:rails org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 invoker.goals.4 = verify
 invoker.mavenOpts = -client
 #invoker.offline = true

--- a/integration-tests/src/it/new_latest_rails_postgres/invoker.properties
+++ b/integration-tests/src/it/new_latest_rails_postgres/invoker.properties
@@ -1,6 +1,6 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:new de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:new org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 invoker.goals.4 = verify
 invoker.mavenOpts = -client
 #invoker.offline = true

--- a/integration-tests/src/it/new_latest_rails_sqlite3/invoker.properties
+++ b/integration-tests/src/it/new_latest_rails_sqlite3/invoker.properties
@@ -1,5 +1,5 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:new de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:bundler-maven-plugin:${project.version}:install de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:new org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:bundler-maven-plugin:${project.version}:install org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 #invoker.goals.4 = verify
 invoker.mavenOpts = -client

--- a/integration-tests/src/it/new_rails_3_0_11_sqlite3/invoker.properties
+++ b/integration-tests/src/it/new_rails_3_0_11_sqlite3/invoker.properties
@@ -1,6 +1,6 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:new de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:new org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 invoker.goals.4 = verify
 invoker.mavenOpts = -client
 #invoker.offline = true

--- a/integration-tests/src/it/new_rails_3_0_11_sqlite3_datamapper/invoker.properties
+++ b/integration-tests/src/it/new_rails_3_0_11_sqlite3_datamapper/invoker.properties
@@ -1,5 +1,5 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:new de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:new org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 #invoker.goals.4 = verify
 invoker.mavenOpts = -client

--- a/integration-tests/src/it/new_rails_3_0_11_sqlite3_offline/invoker.properties
+++ b/integration-tests/src/it/new_rails_3_0_11_sqlite3_offline/invoker.properties
@@ -1,6 +1,6 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:new de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:bundler-maven-plugin:${project.version}:install de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:new org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:bundler-maven-plugin:${project.version}:install org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 invoker.goals.4 = verify
 invoker.mavenOpts = -client
 invoker.offline = true

--- a/integration-tests/src/it/new_rails_3_2_5_sqlite3/invoker.properties
+++ b/integration-tests/src/it/new_rails_3_2_5_sqlite3/invoker.properties
@@ -1,6 +1,6 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:new de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:bundler-maven-plugin:${project.version}:install de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:new org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:bundler-maven-plugin:${project.version}:install org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 invoker.goals.4 = verify
 invoker.mavenOpts = -client
 #invoker.offline = true

--- a/integration-tests/src/it/pending_new_rails_3_1_1_sqlite3_offline/invoker.properties
+++ b/integration-tests/src/it/pending_new_rails_3_1_1_sqlite3_offline/invoker.properties
@@ -1,6 +1,6 @@
-invoker.goals = de.saumya.mojo:rails3-maven-plugin:${project.version}:new de.saumya.mojo:jruby-maven-plugin:${project.version}:jruby
-invoker.goals.2 = de.saumya.mojo:rails3-maven-plugin:${project.version}:generate
-invoker.goals.3 = de.saumya.mojo:rails3-maven-plugin:${project.version}:rake
+invoker.goals = org.jruby.maven:rails3-maven-plugin:${project.version}:new org.jruby.maven:jruby-maven-plugin:${project.version}:jruby
+invoker.goals.2 = org.jruby.maven:rails3-maven-plugin:${project.version}:generate
+invoker.goals.3 = org.jruby.maven:rails3-maven-plugin:${project.version}:rake
 invoker.goals.4 = verify
 invoker.mavenOpts = -client
 #invoker.offline = true

--- a/jruby-maven-plugin/pom.xml
+++ b/jruby-maven-plugin/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>jruby-maven-plugin</artifactId>
@@ -12,7 +12,7 @@
   <name>JRuby Maven Mojo</name>
   <dependencies>
     <dependency>
-      <groupId>de.saumya.mojo</groupId>
+      <groupId>org.jruby.maven</groupId>
       <artifactId>ruby-tools</artifactId>
       <version>${project.parent.version}</version>
       <exclusions>

--- a/jruby-maven-plugin/src/it/compile-dir/pom.xml
+++ b/jruby-maven-plugin/src/it/compile-dir/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/jruby-maven-plugin/src/it/compile-failures-but-ignore-failures/pom.xml
+++ b/jruby-maven-plugin/src/it/compile-failures-but-ignore-failures/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<configuration>

--- a/jruby-maven-plugin/src/it/compile-failures/pom.xml
+++ b/jruby-maven-plugin/src/it/compile-failures/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
 	<version>@project.version@</version>
       </plugin>

--- a/jruby-maven-plugin/src/it/compile-verbose/pom.xml
+++ b/jruby-maven-plugin/src/it/compile-verbose/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
 	<version>@project.version@</version>
       </plugin>

--- a/jruby-maven-plugin/src/it/exec-embed/pom.xml
+++ b/jruby-maven-plugin/src/it/exec-embed/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
  <version>@project.version@</version>
       </plugin>

--- a/jruby-maven-plugin/src/it/exec-file-from-lib/pom.xml
+++ b/jruby-maven-plugin/src/it/exec-file-from-lib/pom.xml
@@ -7,7 +7,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>jruby-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/jruby-maven-plugin/src/it/exec-file-from-ruby-source-directory/pom.xml
+++ b/jruby-maven-plugin/src/it/exec-file-from-ruby-source-directory/pom.xml
@@ -7,7 +7,7 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>jruby-maven-plugin</artifactId>
 	<version>@project.parent.version@</version>
 	<configuration>

--- a/jruby-maven-plugin/src/it/exec-file/pom.xml
+++ b/jruby-maven-plugin/src/it/exec-file/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/jruby-maven-plugin/src/it/generate-java-and-compile/pom.xml
+++ b/jruby-maven-plugin/src/it/generate-java-and-compile/pom.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
   <dependencies>
@@ -16,7 +16,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/jruby-maven-plugin/src/it/jruby-version/goals.txt
+++ b/jruby-maven-plugin/src/it/jruby-version/goals.txt
@@ -1,1 +1,1 @@
-de.saumya.mojo:jruby-maven-plugin:jruby
+org.jruby.maven:jruby-maven-plugin:jruby

--- a/jruby-maven-plugin/src/it/jruby-version/pom.xml
+++ b/jruby-maven-plugin/src/it/jruby-version/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/jruby-maven-plugin/src/it/simple-ruby-script-to-outputfile-somewhere/pom.xml
+++ b/jruby-maven-plugin/src/it/simple-ruby-script-to-outputfile-somewhere/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <configuration>

--- a/jruby-maven-plugin/src/it/simple-ruby-script-to-outputfile/pom.xml
+++ b/jruby-maven-plugin/src/it/simple-ruby-script-to-outputfile/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/jruby-maven-plugin/src/it/simple-ruby-script/pom.xml
+++ b/jruby-maven-plugin/src/it/simple-ruby-script/pom.xml
@@ -3,14 +3,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby</artifactId>
   <version>testing</version>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>jruby-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <configuration>

--- a/minitest-maven-plugin/pom.xml
+++ b/minitest-maven-plugin/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>test-parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../test-parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>minitest-maven-plugin</artifactId>

--- a/minitest-maven-plugin/src/it/minispec-with-jar-dependencies/pom.xml
+++ b/minitest-maven-plugin/src/it/minispec-with-jar-dependencies/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>minitest-with-jar-dependencies</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -31,9 +44,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>minitest-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <executions>

--- a/minitest-maven-plugin/src/it/minitest-failure/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-failure/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>minitest-failure</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>minitest-maven-plugin</artifactId>
         <version>@project.version@</version>    
       </plugin>

--- a/minitest-maven-plugin/src/it/minitest-from-jruby/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-from-jruby/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>minitest-from-jruby</artifactId>
   <version>testing</version>  
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>minitest-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<executions>

--- a/minitest-maven-plugin/src/it/minitest-pom-210/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-pom-210/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>minitest-pom</artifactId>
   <version>testing</version>  
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>minitest-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<executions>

--- a/minitest-maven-plugin/src/it/minitest-pom-508/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-pom-508/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>minitest-pom</artifactId>
   <version>testing</version>  
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>minitest-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<executions>

--- a/minitest-maven-plugin/src/it/minitest-somewhere/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-somewhere/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>minitest-somewhere</artifactId>
   <version>testing</version> 
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>minitest-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/minitest-maven-plugin/src/it/minitest-summary-report/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-summary-report/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>minitest-pom</artifactId>
   <version>testing</version>  
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+      <extensions>
+          <extension>
+              <groupId>org.jruby.maven</groupId>
+              <artifactId>mavengem-wagon</artifactId>
+              <version>2.0.0-SNAPSHOT</version>
+          </extension>
+      </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>minitest-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<executions>

--- a/parent-mojo/pom.xml
+++ b/parent-mojo/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>de.saumya.mojo</groupId>
+    <groupId>org.jruby.maven</groupId>
     <artifactId>jruby-maven-plugins</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>parent-mojo</artifactId>
   <packaging>pom</packaging>
@@ -59,7 +59,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.9.0</version>
         <executions>
           <execution>
             <phase>process-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <artifactId>oss-parent</artifactId>
     <version>7</version>
   </parent>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-maven-plugins</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>JRuby Maven Mojos</name>
   <description>
     aggregation project for various jruby related maven plugins
@@ -49,6 +49,19 @@
     </dependency>
   </dependencies>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
       <id>sonatype</id>
@@ -63,6 +76,13 @@
   </repositories>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <pluginManagement>
       <plugins>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/rake-maven-plugin/pom.xml
+++ b/rake-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>gem-parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
+    <groupId>org.jruby.maven</groupId>
     <version>2.0.1-SNAPSHOT</version>
     <relativePath>../gem-parent-mojo/pom.xml</relativePath>
   </parent>

--- a/rake-maven-plugin/src/it/rake-file/invoker.properties
+++ b/rake-maven-plugin/src/it/rake-file/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals = de.saumya.mojo:rake-maven-plugin:rake
+invoker.goals = org.jruby.maven:rake-maven-plugin:rake
 invoker.mavenOpts = -client

--- a/rake-maven-plugin/src/it/rake-file/pom.xml
+++ b/rake-maven-plugin/src/it/rake-file/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>rake-file</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -21,9 +34,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rake-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<extensions>true</extensions>

--- a/rake-maven-plugin/src/it/rake-somewhere/invoker.properties
+++ b/rake-maven-plugin/src/it/rake-somewhere/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals = de.saumya.mojo:rake-maven-plugin:rake
+invoker.goals = org.jruby.maven:rake-maven-plugin:rake
 invoker.mavenOpts = -client

--- a/rake-maven-plugin/src/it/rake-somewhere/pom.xml
+++ b/rake-maven-plugin/src/it/rake-somewhere/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>jruby-version</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -21,15 +34,22 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<extensions>true</extensions>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rake-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/rake-maven-plugin/src/it/rake-tasks/invoker.properties
+++ b/rake-maven-plugin/src/it/rake-tasks/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals = de.saumya.mojo:rake-maven-plugin:rake
+invoker.goals = org.jruby.maven:rake-maven-plugin:rake
 invoker.mavenOpts = -client

--- a/rake-maven-plugin/src/it/rake-tasks/pom.xml
+++ b/rake-maven-plugin/src/it/rake-tasks/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>rake-task</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -21,9 +34,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rake-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<extensions>true</extensions>

--- a/rspec-maven-plugin/pom.xml
+++ b/rspec-maven-plugin/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>test-parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../test-parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>rspec-maven-plugin</artifactId>

--- a/rspec-maven-plugin/src/it/rspec-3.x/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-3.x/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-success</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -24,9 +37,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <extensions>true</extensions>

--- a/rspec-maven-plugin/src/it/rspec-failure/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-failure/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-success</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -24,9 +37,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
       </plugin>

--- a/rspec-maven-plugin/src/it/rspec-path/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-path/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-success</artifactId>
   <version>testing</version>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -24,9 +37,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <extensions>true</extensions>

--- a/rspec-maven-plugin/src/it/rspec-pom/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-pom/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-success</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -24,9 +37,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
         <extensions>true</extensions>

--- a/rspec-maven-plugin/src/it/rspec-somewhere/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-somewhere/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-somewhere</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -24,9 +37,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<configuration>

--- a/rspec-maven-plugin/src/it/rspec-summary-report/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-summary-report/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-success</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -24,9 +37,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<executions>

--- a/rspec-maven-plugin/src/it/rspec-with-jar-dependencies/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-with-jar-dependencies/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-success</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -31,9 +44,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
       </plugin>

--- a/rspec-maven-plugin/src/it/with-custom-specs-path/pom.xml
+++ b/rspec-maven-plugin/src/it/with-custom-specs-path/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-file</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -24,9 +37,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<executions>

--- a/rspec-maven-plugin/src/it/with-error-in-before/pom.xml
+++ b/rspec-maven-plugin/src/it/with-error-in-before/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-success</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -24,9 +37,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
       </plugin>

--- a/rspec-maven-plugin/src/it/with-java-classes/pom.xml
+++ b/rspec-maven-plugin/src/it/with-java-classes/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-success</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -29,9 +42,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
       </plugin>

--- a/rspec-maven-plugin/src/it/without-specs-path/pom.xml
+++ b/rspec-maven-plugin/src/it/without-specs-path/pom.xml
@@ -3,14 +3,27 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>spec-file</artifactId>
   <version>testing</version>
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -24,9 +37,16 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>rspec-maven-plugin</artifactId>
 	<version>@project.version@</version>
 	<executions>

--- a/ruby-tools/pom.xml
+++ b/ruby-tools/pom.xml
@@ -3,11 +3,11 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>jruby-maven-plugins</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>ruby-tools</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>Ruby Tools</name>
   <dependencies>
     <dependency>
@@ -78,13 +78,6 @@
     <gem.path>${root.dir}/target/rubygems</gem.path>
   </properties>
   <build>
-      <extensions>
-          <extension>
-              <groupId>org.torquebox.mojo</groupId>
-              <artifactId>mavengem-wagon</artifactId>
-              <version>1.0.3</version>
-          </extension>
-      </extensions>
       <resources>
       <resource>
         <directory>${basedir}/src/main/resources</directory>
@@ -182,7 +175,7 @@
     <profile> 
       <!--
 	 that profile looks for the development setup and then gets all the 
-         needed gems from http://rubygems-proxy.torquebox.org/releases
+         needed gems from mavengem:https://rubygems.org
          this repo does not show when the pom is used from maven central
 	 
 	 all the gems here are embedded into the jar itself, i.e. those
@@ -195,6 +188,19 @@
           <exists>../jruby-maven-plugin</exists>
         </file>
       </activation>
+
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <id>sonatype</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </pluginRepository>
+      </pluginRepositories>
 
       <repositories>
 	<repository>

--- a/ruby-tools/src/main/java/de/saumya/mojo/ruby/script/EmbeddedLauncher.java
+++ b/ruby-tools/src/main/java/de/saumya/mojo/ruby/script/EmbeddedLauncher.java
@@ -108,15 +108,10 @@ class EmbeddedLauncher extends AbstractLauncher {
     private void doExecute(final File launchDirectory, final File outputFile,
             final List<String> args, final boolean warn)
             throws ScriptException, IOException {
-        final String currentDir;
         if (launchDirectory != null) {
-            currentDir = System.getProperty("user.dir");
-            logger.debug("launch directory: "
-                    + launchDirectory.getAbsolutePath());
-            System.setProperty("user.dir", launchDirectory.getAbsolutePath());
-        }
-        else {
-            currentDir = null;
+            // pass -C <dir> to JRuby
+            args.add(0, "-C");
+            args.add(1, launchDirectory.getAbsolutePath());
         }
 
         args.addAll(0, this.factory.switches.list);
@@ -197,9 +192,6 @@ class EmbeddedLauncher extends AbstractLauncher {
                 Thread.currentThread().setContextClassLoader(current);
             }
             System.setOut(output);
-            if (currentDir != null) {
-                System.setProperty("user.dir", currentDir);
-            }
             if (this.classRealm != null) {
                 try {
                     this.classRealm.getWorld().disposeRealm("pom");

--- a/runit-maven-plugin/pom.xml
+++ b/runit-maven-plugin/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>test-parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../test-parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>runit-maven-plugin</artifactId>

--- a/runit-maven-plugin/src/it/runit-failure/pom.xml
+++ b/runit-maven-plugin/src/it/runit-failure/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>runit-failure</artifactId>
   <version>testing</version>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>runit-maven-plugin</artifactId>
         <version>@project.version@</version>    
       </plugin>

--- a/runit-maven-plugin/src/it/runit-pom/pom.xml
+++ b/runit-maven-plugin/src/it/runit-pom/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>runit-pom</artifactId>
   <version>testing</version>  
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>runit-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<executions>

--- a/runit-maven-plugin/src/it/runit-somewhere/pom.xml
+++ b/runit-maven-plugin/src/it/runit-somewhere/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>runit-somewhere</artifactId>
   <version>testing</version> 
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>runit-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/runit-maven-plugin/src/it/runit-summary-report/pom.xml
+++ b/runit-maven-plugin/src/it/runit-summary-report/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>runit-pom</artifactId>
   <version>testing</version>  
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>runit-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<executions>

--- a/runit-maven-plugin/src/it/runit-with-env/pom.xml
+++ b/runit-maven-plugin/src/it/runit-with-env/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>runit-pom</artifactId>
   <version>testing</version>  
 
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -23,9 +36,16 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>runit-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/runit-maven-plugin/src/it/runit-with-jar-dependencies/pom.xml
+++ b/runit-maven-plugin/src/it/runit-with-jar-dependencies/pom.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>de.saumya.mojo</groupId>
+  <groupId>org.jruby.maven</groupId>
   <artifactId>runit-pom</artifactId>
   <version>testing</version>  
-  
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
-      <id>rubygems-releases</id>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
 
@@ -31,9 +44,16 @@
   </dependencies>
   
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.jruby.maven</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>runit-maven-plugin</artifactId>
         <version>@project.version@</version>
 	<executions>

--- a/test-base-plugin/pom.xml
+++ b/test-base-plugin/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>gem-parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../gem-parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>test-base-plugin</artifactId>

--- a/test-parent-mojo/pom.xml
+++ b/test-parent-mojo/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>gem-parent-mojo</artifactId>
-    <groupId>de.saumya.mojo</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <groupId>org.jruby.maven</groupId>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../gem-parent-mojo/pom.xml</relativePath>
   </parent>
   <artifactId>test-parent-mojo</artifactId>


### PR DESCRIPTION
This makes the following changes:

* de.saumya.mojo maven group ID changes to org.jruby.maven in all published artifacts
* mavengem is used for all gem retrieval instead of the defunct TorqueBox proxy server
* mavengem and related dependencies are now sourced from the org.jruby.maven 2.0.0 versions
* minor additional changes to get tests passing with the new artifacts

This passes all unit and integration tests and deploys successfully as org.jruby.maven:jruby-maven-plugins:3.0.0-SNAPSHOT and should now be immune to the v1/dependencies rubygems.org API shutdown (jruby/mavengem#8).