### PR TITLE
Update to mavengem 2.0.0

### DIFF
--- a/gem-maven-plugin/src/it/exec-file/pom.xml
+++ b/gem-maven-plugin/src/it/exec-file/pom.xml
@@ -44,7 +44,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/gem-maven-plugin/src/it/execute-compass-with-gems-from-plugin/pom.xml
+++ b/gem-maven-plugin/src/it/execute-compass-with-gems-from-plugin/pom.xml
@@ -37,7 +37,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/gem-maven-plugin/src/it/gem-sets/pom.xml
+++ b/gem-maven-plugin/src/it/gem-sets/pom.xml
@@ -32,7 +32,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>
@@ -58,7 +58,7 @@
 	    <configuration>
 	      <scope>test</scope>
 	      <gems>
-		<maven-tools>1.0.0.rc5</maven-tools>
+		<maven-tools>1.2.0</maven-tools>
 		<virtus>1.0.2</virtus>
 		<descendants_tracker>0.0.4</descendants_tracker>
 		<thread_safe>0.3.4</thread_safe>

--- a/gem-maven-plugin/src/it/gems-with-compile-test-and-provided-scope/pom.xml
+++ b/gem-maven-plugin/src/it/gems-with-compile-test-and-provided-scope/pom.xml
@@ -60,7 +60,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/gem-maven-plugin/src/it/include-rubygems-in-resources/pom.xml
+++ b/gem-maven-plugin/src/it/include-rubygems-in-resources/pom.xml
@@ -58,7 +58,7 @@
             <extension>
                 <groupId>org.jruby.maven</groupId>
                 <artifactId>mavengem-wagon</artifactId>
-                <version>2.0.0-SNAPSHOT</version>
+                <version>2.0.0</version>
             </extension>
         </extensions>
         <plugins>

--- a/gem-maven-plugin/src/it/include-rubygems-in-test-resources/pom.xml
+++ b/gem-maven-plugin/src/it/include-rubygems-in-test-resources/pom.xml
@@ -52,7 +52,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/gem-maven-plugin/src/it/initialize/pom.xml
+++ b/gem-maven-plugin/src/it/initialize/pom.xml
@@ -58,7 +58,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/gem-maven-plugin/src/it/jars-lock/pom.xml
+++ b/gem-maven-plugin/src/it/jars-lock/pom.xml
@@ -50,7 +50,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/gem-maven-plugin/src/it/script-inside-pom/pom.xml
+++ b/gem-maven-plugin/src/it/script-inside-pom/pom.xml
@@ -12,7 +12,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/minitest-maven-plugin/src/it/minispec-with-jar-dependencies/pom.xml
+++ b/minitest-maven-plugin/src/it/minispec-with-jar-dependencies/pom.xml
@@ -48,7 +48,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/minitest-maven-plugin/src/it/minitest-failure/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-failure/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/minitest-maven-plugin/src/it/minitest-from-jruby/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-from-jruby/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/minitest-maven-plugin/src/it/minitest-pom-508/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-pom-508/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/minitest-maven-plugin/src/it/minitest-somewhere/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-somewhere/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/minitest-maven-plugin/src/it/minitest-summary-report/pom.xml
+++ b/minitest-maven-plugin/src/it/minitest-summary-report/pom.xml
@@ -40,7 +40,7 @@
           <extension>
               <groupId>org.jruby.maven</groupId>
               <artifactId>mavengem-wagon</artifactId>
-              <version>2.0.0-SNAPSHOT</version>
+              <version>2.0.0</version>
           </extension>
       </extensions>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
   <build>
     <extensions>
       <extension>
-        <groupId>org.torquebox.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>1.0.3</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <pluginManagement>

--- a/rake-maven-plugin/src/it/rake-file/pom.xml
+++ b/rake-maven-plugin/src/it/rake-file/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rake-maven-plugin/src/it/rake-somewhere/pom.xml
+++ b/rake-maven-plugin/src/it/rake-somewhere/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rake-maven-plugin/src/it/rake-tasks/pom.xml
+++ b/rake-maven-plugin/src/it/rake-tasks/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/rspec-3.x/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-3.x/pom.xml
@@ -41,7 +41,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/rspec-failure/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-failure/pom.xml
@@ -41,7 +41,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/rspec-path/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-path/pom.xml
@@ -41,7 +41,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/rspec-pom/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-pom/pom.xml
@@ -41,7 +41,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/rspec-somewhere/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-somewhere/pom.xml
@@ -41,7 +41,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/rspec-summary-report/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-summary-report/pom.xml
@@ -41,7 +41,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/rspec-with-jar-dependencies/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-with-jar-dependencies/pom.xml
@@ -48,7 +48,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/with-custom-specs-path/pom.xml
+++ b/rspec-maven-plugin/src/it/with-custom-specs-path/pom.xml
@@ -41,7 +41,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/with-error-in-before/pom.xml
+++ b/rspec-maven-plugin/src/it/with-error-in-before/pom.xml
@@ -41,7 +41,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/with-java-classes/pom.xml
+++ b/rspec-maven-plugin/src/it/with-java-classes/pom.xml
@@ -46,7 +46,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/rspec-maven-plugin/src/it/without-specs-path/pom.xml
+++ b/rspec-maven-plugin/src/it/without-specs-path/pom.xml
@@ -41,7 +41,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/ruby-tools/pom.xml
+++ b/ruby-tools/pom.xml
@@ -213,7 +213,7 @@
         <dependency>
           <groupId>rubygems</groupId>
           <artifactId>maven-tools</artifactId>
-          <version>1.1.6</version>
+          <version>1.2.0</version>
           <type>gem</type>
           <scope>provided</scope>
         </dependency>

--- a/runit-maven-plugin/src/it/runit-failure/pom.xml
+++ b/runit-maven-plugin/src/it/runit-failure/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/runit-maven-plugin/src/it/runit-pom/pom.xml
+++ b/runit-maven-plugin/src/it/runit-pom/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/runit-maven-plugin/src/it/runit-somewhere/pom.xml
+++ b/runit-maven-plugin/src/it/runit-somewhere/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/runit-maven-plugin/src/it/runit-summary-report/pom.xml
+++ b/runit-maven-plugin/src/it/runit-summary-report/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/runit-maven-plugin/src/it/runit-with-env/pom.xml
+++ b/runit-maven-plugin/src/it/runit-with-env/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>

--- a/runit-maven-plugin/src/it/runit-with-jar-dependencies/pom.xml
+++ b/runit-maven-plugin/src/it/runit-with-jar-dependencies/pom.xml
@@ -48,7 +48,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
       </extension>
     </extensions>
     <plugins>


### PR DESCRIPTION
This was not possible before the 3.0.0 release because of the difficulty of releasing new versions of both mavengem and jruby-maven-plugins at the same time. Until we can build and release them simultaneously, mavengem and the plugins will be off one version.